### PR TITLE
Allow to find column without table name

### DIFF
--- a/Sources/MySQL/Connection/MySQLColumn.swift
+++ b/Sources/MySQL/Connection/MySQLColumn.swift
@@ -72,6 +72,9 @@ extension Dictionary where Key == MySQLColumn {
         } else if let unspecific = self[MySQLColumn(table: nil, name: columnName)] {
             // check for column without table name
             return unspecific
+        } else if let unspecific = self.first(where: { $0.key.name == columnName }) {
+            // check for column without table name
+            return unspecific.value
         } else if table == nil {
             // check for column with table name where we don't specify one
             for (col, row) in self {


### PR DESCRIPTION
This is the patch to support queries with table aliases like described in #243 