### PR TITLE
Correctly decode null columns

### DIFF
--- a/Sources/MySQLKit/MySQLDatabase.swift
+++ b/Sources/MySQLKit/MySQLDatabase.swift
@@ -105,7 +105,10 @@ extension MySQLRow: SQLRow {
     }
 
     public func decodeNil(column: String) throws -> Bool {
-        self.column(column) == nil
+        guard let data = self.column(column) else {
+            return true
+        }
+        return data.buffer == nil
     }
 
     public func decode<D>(column: String, as type: D.Type) throws -> D where D : Decodable {

--- a/Tests/MySQLKitTests/MySQLKitTests.swift
+++ b/Tests/MySQLKitTests/MySQLKitTests.swift
@@ -8,6 +8,18 @@ class MySQLKitTests: XCTestCase {
         try self.benchmark.testEnum()
     }
 
+    func testNullDecode() throws {
+        struct Person: Codable {
+            let id: Int
+            let name: String?
+        }
+
+        let rows = try self.db.raw("SELECT 1 as `id`, null as `name`")
+            .all(decoding: Person.self).wait()
+        XCTAssertEqual(rows[0].id, 1)
+        XCTAssertEqual(rows[0].name, nil)
+    }
+
     var db: SQLDatabase {
         self.connection.sql()
     }


### PR DESCRIPTION
Fixes a bug causing columns with null values to not correctly decode to Swift optionals (fixes #255, #256).