### PR TITLE
Add unix socket option to MySQLConfiguration

### DIFF
--- a/Sources/MySQLKit/MySQLDatabase.swift
+++ b/Sources/MySQLKit/MySQLDatabase.swift
@@ -43,6 +43,22 @@ public struct MySQLConfiguration {
             tlsConfiguration: tlsConfiguration
         )
     }
+
+    public init(
+        unixDomainSocketPath: String,
+        username: String,
+        password: String,
+        database: String
+    ) {
+        self.address = {
+            return try SocketAddress.init(unixDomainSocketPath: unixDomainSocketPath)
+        }
+        self.username = username
+        self.password = password
+        self.database = database
+        self.tlsConfiguration = nil
+        self._hostname = nil
+    }
     
     public init(
         hostname: String,


### PR DESCRIPTION
Adds `MySQLConfiguration(unixDomainSocketPath:)` initializer for connecting to MySQL over a unix socket (#263, https://github.com/vapor/fluent-mysql-driver/issues/161).