### PR TITLE
Allow optional database in MySQLConfiguration

### DIFF
--- a/Sources/MySQLKit/MySQLDatabase.swift
+++ b/Sources/MySQLKit/MySQLDatabase.swift
@@ -48,7 +48,7 @@ public struct MySQLConfiguration {
         unixDomainSocketPath: String,
         username: String,
         password: String,
-        database: String
+        database: String? = nil
     ) {
         self.address = {
             return try SocketAddress.init(unixDomainSocketPath: unixDomainSocketPath)


### PR DESCRIPTION
Small fix to allow optional `database` string in new `MySQLConfiguration` for unix domain socket path (#264). 