### PR TITLE
Use VARCHAR instead of TEXT

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/mysql-nio.git", from: "1.0.0-rc.1"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.0.0-rc.1"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.0.0-rc.1.2"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0-rc.1"),
 
     ],

--- a/Sources/MySQLKit/MySQLDatabase.swift
+++ b/Sources/MySQLKit/MySQLDatabase.swift
@@ -186,6 +186,15 @@ public struct MySQLDialect: SQLDialect {
         .inline
     }
 
+    public func customDataType(for dataType: SQLDataType) -> SQLExpression? {
+        switch dataType {
+        case .text:
+            return SQLRaw("VARCHAR(255)")
+        default:
+            return nil
+        }
+    }
+
     public var alterTableSyntax: SQLAlterTableSyntax {
         .init(
             alterColumnDefinitionClause: SQLRaw("MODIFY COLUMN"),

--- a/Tests/MySQLKitTests/MySQLKitTests.swift
+++ b/Tests/MySQLKitTests/MySQLKitTests.swift
@@ -40,6 +40,9 @@ class MySQLKitTests: XCTestCase {
         self.connection = try! MySQLConnection.test(
             on: self.eventLoopGroup.next()
         ).wait()
+        _ = try! self.connection.simpleQuery("DROP DATABASE vapor_database").wait()
+        _ = try! self.connection.simpleQuery("CREATE DATABASE vapor_database").wait()
+        _ = try! self.connection.simpleQuery("USE vapor_database").wait()
     }
 
     override func tearDown() {


### PR DESCRIPTION
Overrides `SQLDataType.text` to use `VARCHAR` instead of `TEXT` (#265). 