### PR TITLE
Require the new semver-major RC of mysql-nio

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "MySQLKit", targets: ["MySQLKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/mysql-nio.git", from: "1.0.0-rc.1"),
+        .package(url: "https://github.com/vapor/mysql-nio.git", from: "1.0.0-rc.2"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.0.0-rc.2"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0-rc.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),


### PR DESCRIPTION
Semver-major is more trouble than it's worth sometimes.

Need a new release to bump `Package.swift`. There's no change to MySQLKit's API whatsoever so it's semver-patch here.