### PR TITLE
Change underlying MySQL type for a '.text' field to 'TEXT'. Issue #29…

### DIFF
--- a/Sources/MySQLKit/MySQLDialect.swift
+++ b/Sources/MySQLKit/MySQLDialect.swift
@@ -43,7 +43,7 @@ public struct MySQLDialect: SQLDialect {
     public func customDataType(for dataType: SQLDataType) -> SQLExpression? {
         switch dataType {
         case .text:
-            return SQLRaw("VARCHAR(255)")
+            return SQLRaw("TEXT")
         default:
             return nil
         }


### PR DESCRIPTION
…0 refers.