### PR TITLE
Make unit tests respect env var overrides for DB connection

### DIFF
--- a/Tests/MySQLKitTests/MySQLKitTests.swift
+++ b/Tests/MySQLKitTests/MySQLKitTests.swift
@@ -72,10 +72,10 @@ class MySQLKitTests: XCTestCase {
         self.pools = .init(
             source: .init(configuration: .init(
                 hostname: env("MYSQL_HOSTNAME") ?? "localhost",
-                port: 3306,
-                username: "vapor_username",
-                password: "vapor_password",
-                database: "vapor_database",
+                port: (env("MYSQL_PORT").flatMap({ Int($0) }) ?? 3306) as Int,
+                username: env("MYSQL_USERNAME") ?? "vapor_username",
+                password: env("MYSQL_PASSWORD") ?? "vapor_password",
+                database: env("MYSQL_DATABASE") ?? "vapor_database",
                 tlsConfiguration: .forClient(certificateVerification: .none)
             )),
             maxConnectionsPerEventLoop: 2,
@@ -100,23 +100,6 @@ class MySQLKitTests: XCTestCase {
         try self.eventLoopGroup.syncShutdownGracefully()
         self.eventLoopGroup = nil
         try super.tearDownWithError()
-    }
-}
-
-extension MySQLConnection {
-    static func test(on eventLoop: EventLoop) -> EventLoopFuture<MySQLConnection> {
-        do {
-            return try self.connect(
-                to: .makeAddressResolvingHost(env("MYSQL_HOSTNAME") ?? "localhost", port: 3306),
-                username: "vapor_username",
-                database: "vapor_database",
-                password: "vapor_password",
-                tlsConfiguration: .forClient(certificateVerification: .none),
-                on: eventLoop
-            )
-        } catch {
-            return eventLoop.makeFailedFuture(error)
-        }
     }
 }
 

--- a/Tests/MySQLKitTests/MySQLKitTests.swift
+++ b/Tests/MySQLKitTests/MySQLKitTests.swift
@@ -72,7 +72,7 @@ class MySQLKitTests: XCTestCase {
         self.pools = .init(
             source: .init(configuration: .init(
                 hostname: env("MYSQL_HOSTNAME") ?? "localhost",
-                port: (env("MYSQL_PORT").flatMap({ Int($0) }) ?? 3306) as Int,
+                port: env("MYSQL_PORT").flatMap(Int.init) ?? 3306,
                 username: env("MYSQL_USERNAME") ?? "vapor_username",
                 password: env("MYSQL_PASSWORD") ?? "vapor_password",
                 database: env("MYSQL_DATABASE") ?? "vapor_database",


### PR DESCRIPTION
The unit tests now respect `MYSQL_USERNAME`, `MYSQL_PASSWORD`, `MYSQL_DATABASE`, and `MYSQL_PORT`. (`MYSQL_HOSTNAME` was already supported.)

No semver tag as updating the unit tests does not require a release.