### PR TITLE
Address issues in decoding data from the database

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: vapor/${{ matrix.dependent }}
           path: dependent
-          ref: master
+          ref: main
       - name: Use local package
         run: swift package edit mysql-kit --path ../package
         working-directory: dependent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: test
-on: 
-  - pull_request
+on:
+  pull_request:
+  push: { branches: [ main ] }
 defaults:
   run:
     shell: bash
@@ -22,7 +23,7 @@ jobs:
           MYSQL_USER: vapor_username
           MYSQL_PASSWORD: vapor_password
           MYSQL_DATABASE: vapor_database
-    container: swift:5.2-bionic
+    container: swift:5.4-focal
     strategy:
       fail-fast: false
       matrix:
@@ -63,14 +64,11 @@ jobs:
           - mysql:8.0
           - mariadb:latest
         runner:
-          # 5.2 Stable
-          - swift:5.2-bionic
-          # 5.2 Unstable
-          - swiftlang/swift:nightly-5.2-bionic
-          # 5.3 Unstable
-          - swiftlang/swift:nightly-5.3-bionic
-          # Master Unsable
-          - swiftlang/swift:nightly-master-focal
+          - swift:5.2-focal
+          - swift:5.3-focal
+          - swift:5.4-focal
+          - swiftlang/swift:nightly-5.5-focal
+          - swiftlang/swift:nightly-main-focal
     container: ${{ matrix.runner }}
     runs-on: ubuntu-latest
     services:
@@ -97,6 +95,9 @@ jobs:
           - mysql@8.0
           - mysql@5.7
           - mariadb
+        version:
+          - latest
+          - latest-stable
         include:
           - username: root
           - formula: mariadb
@@ -104,9 +105,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Select latest available Xcode
-        uses: maxim-lobanov/setup-xcode@1.0
+        uses: maxim-lobanov/setup-xcode@v1
         with: 
-          xcode-version: latest
+          xcode-version: ${{ matrix.version }}
       - name: Install MySQL server from Homebrew
         run: brew install ${{ matrix.formula }} && brew link --force ${{ matrix.formula }}
       - name: Start MySQL server
@@ -129,4 +130,3 @@ jobs:
           MYSQL_HOSTNAME: '127.0.0.1'
           MYSQL_DATABASE: vapor_database
           LOG_LEVEL: info
-

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.0.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
     ],
     targets: [
         .target(name: "MySQLKit", dependencies: [
@@ -21,6 +22,7 @@ let package = Package(
             .product(name: "MySQLNIO", package: "mysql-nio"),
             .product(name: "SQLKit", package: "sql-kit"),
             .product(name: "Crypto", package: "swift-crypto"),
+            .product(name: "NIOFoundationCompat", package: "swift-nio"),
         ]),
         .testTarget(name: "MySQLKitTests", dependencies: [
             .target(name: "MySQLKit"),

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
     ],
     targets: [
         .target(name: "MySQLKit", dependencies: [
@@ -23,6 +24,7 @@ let package = Package(
             .product(name: "SQLKit", package: "sql-kit"),
             .product(name: "Crypto", package: "swift-crypto"),
             .product(name: "NIOFoundationCompat", package: "swift-nio"),
+            .product(name: "NIOSSL", package: "swift-nio-ssl"),
         ]),
         .testTarget(name: "MySQLKitTests", dependencies: [
             .target(name: "MySQLKit"),

--- a/Sources/MySQLKit/MySQLConfiguration.swift
+++ b/Sources/MySQLKit/MySQLConfiguration.swift
@@ -41,7 +41,7 @@ public struct MySQLConfiguration {
         if url.query == "ssl=false" {
             tlsConfiguration = nil
         } else {
-            tlsConfiguration = .forClient()
+            tlsConfiguration = .makeClientConfiguration()
         }
         
         self.init(
@@ -76,7 +76,7 @@ public struct MySQLConfiguration {
         username: String,
         password: String,
         database: String? = nil,
-        tlsConfiguration: TLSConfiguration? = .forClient()
+        tlsConfiguration: TLSConfiguration? = .makeClientConfiguration()
     ) {
         self.address = {
             return try SocketAddress.makeAddressResolvingHost(hostname, port: port)

--- a/Sources/MySQLKit/MySQLDataDecoder.swift
+++ b/Sources/MySQLKit/MySQLDataDecoder.swift
@@ -1,26 +1,21 @@
 import Foundation
+import MySQLNIO
+import NIOFoundationCompat
 
-private struct DecoderUnwrapper: Decodable {
-    let decoder: Decoder
-    init(from decoder: Decoder) {
-        self.decoder = decoder
-    }
-}
-
-private struct Wrapper<D>: Decodable where D: Decodable {
-    var value: D
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.value = try container.decode(D.self)
-    }
-}
-
-extension MySQLData {
-    var data: Data? {
-        self.buffer.flatMap {
-            .init($0.readableBytesView)
+extension Optional: MySQLDataConvertible where Wrapped: MySQLDataConvertible {
+    public init?(mysqlData: MySQLData) {
+        if mysqlData.buffer != nil {
+            guard let value = Wrapped.init(mysqlData: mysqlData) else {
+                return nil
+            }
+            self = .some(value)
+        } else {
+            self = .none
         }
+    }
+    
+    public var mysqlData: MySQLData? {
+        return self.flatMap { $0.mysqlData }
     }
 }
 
@@ -34,81 +29,60 @@ public struct MySQLDataDecoder {
     public func decode<T>(_ type: T.Type, from data: MySQLData) throws -> T
         where T: Decodable
     {
+        // If `T` can be converted directly, just do so.
         if let convertible = T.self as? MySQLDataConvertible.Type {
             guard let value = convertible.init(mysqlData: data) else {
-                throw DecodingError.typeMismatch(T.self, DecodingError.Context(
+                throw DecodingError.typeMismatch(T.self, .init(
                     codingPath: [],
-                    debugDescription: "Could not convert MySQL data to \(T.self): \(data)",
-                    underlyingError: nil
+                    debugDescription: "Could not convert MySQL data to \(T.self): \(data)"
                 ))
             }
             return value as! T
         } else {
-            return try T.init(from: _Decoder(data: data, json: self.json))
+            // Probably either a JSON array/object or an enum type not using @Enum. See if it can be "unwrapped" as a
+            // single-value decoding container, since this is much faster than attempting a JSON decode; this will
+            // handle "box" types such as `RawRepresentable` enums and `Optional` (if Optional didn't already directly
+            // conform), but still allow falling back to JSON.
+            do {
+                return try T.init(from: GiftBoxUnwrapDecoder(decoder: self, data: data))
+            } catch DecodingError.dataCorrupted {
+                // Couldn't unwrap it either. Fall back to attempting a JSON decode.
+                return try self.json.decode(T.self, from: data.buffer!)
+            }
         }
     }
     
-    private final class _Decoder: Decoder {
-        var codingPath: [CodingKey] {
-            return []
-        }
-        
-        var userInfo: [CodingUserInfoKey : Any] {
-            return [:]
-        }
+    private final class GiftBoxUnwrapDecoder: Decoder, SingleValueDecodingContainer {
+        var codingPath: [CodingKey] { [] }
+        var userInfo: [CodingUserInfoKey : Any] { [:] }
 
+        let dataDecoder: MySQLDataDecoder
         let data: MySQLData
-        let json: JSONDecoder
-
-        init(data: MySQLData, json: JSONDecoder) {
+        
+        init(decoder: MySQLDataDecoder, data: MySQLData) {
+            self.dataDecoder = decoder
             self.data = data
-            self.json = json
         }
         
         func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-            try self.json
-                .decode(DecoderUnwrapper.self, from: self.data.data!)
-                .decoder.unkeyedContainer()
+            throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Array containers must be JSON-encoded"))
         }
         
-        func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key>
-            where Key : CodingKey
-        {
-            try self.json
-                .decode(DecoderUnwrapper.self, from: self.data.data!)
-                .decoder.container(keyedBy: Key.self)
+        func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key: CodingKey {
+            throw DecodingError.dataCorrupted(.init(codingPath: self.codingPath, debugDescription: "Dictionary containers must be JSON-encoded"))
         }
         
         func singleValueContainer() throws -> SingleValueDecodingContainer {
-            return _SingleValueDecoder(self)
+            return self
         }
-    }
-    
-    private struct _SingleValueDecoder: SingleValueDecodingContainer {
-        var codingPath: [CodingKey] {
-            return self.decoder.codingPath
-        }
-        let decoder: _Decoder
-        init(_ decoder: _Decoder) {
-            self.decoder = decoder
-        }
-        
+
         func decodeNil() -> Bool {
-            return self.decoder.data.buffer == nil
+            self.data.buffer == nil
         }
-        
+
         func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
-            if let convertible = T.self as? MySQLDataConvertible.Type {
-                guard let value = convertible.init(mysqlData: self.decoder.data) else {
-                    throw DecodingError.typeMismatch(T.self, DecodingError.Context.init(
-                        codingPath: self.codingPath,
-                        debugDescription: "Could not convert MySQL data to \(T.self): \(self.decoder.data)"
-                    ))
-                }
-                return value as! T
-            } else {
-                return try MySQLDataDecoder().decode(T.self, from: self.decoder.data)
-            }
+            // Recurse back into the data decoder, don't repeat its logic here.
+            return try self.dataDecoder.decode(T.self, from: self.data)
         }
     }
 }

--- a/Sources/MySQLKit/MySQLDataDecoder.swift
+++ b/Sources/MySQLKit/MySQLDataDecoder.swift
@@ -15,7 +15,7 @@ extension Optional: MySQLDataConvertible where Wrapped: MySQLDataConvertible {
     }
     
     public var mysqlData: MySQLData? {
-        return self.flatMap { $0.mysqlData }
+        return self.flatMap(\.mysqlData)
     }
 }
 


### PR DESCRIPTION
See commit log for details; in short, the `MySQLDataDecoder` logic has been retooled to fix some usage errors, address a couple of very minor bugs, and slightly improve performance. Additional changes:

- Fixes `TLSConfiguration.forClient()` deprecation warnings by using `.makeClientConfiguration()` instead as recommended.
- Some well-overdue updates to CI for this package.

Note: While these changes do not add any new public API, they are nonetheless marked as `semver-minor` to reflect the addition of a new explicit dependency on a recent version of NIOSSL.