### PR TITLE
Enable UPSERT support for MySQL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
           - mysql:8.0
           - mariadb:10.2
           - mariadb:10.6
+          - percona:5.7
+          - percona:8.0
         dependent:
           - fluent-mysql-driver
     steps:
@@ -94,14 +96,12 @@ jobs:
         formula: 
           - mysql@8.0
           - mysql@5.7
-          - mariadb@10.2
+          - percona-server
           - mariadb@10.6
         version:
           - latest-stable
         include:
           - username: root
-          - formula: mariadb@10.2
-            username: runner
           - formula: mariadb@10.6
             username: runner
     runs-on: macos-11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,15 @@ jobs:
           MYSQL_USER: vapor_username
           MYSQL_PASSWORD: vapor_password
           MYSQL_DATABASE: vapor_database
-    container: swift:5.4-focal
+    container: swift:5.5-focal
     strategy:
       fail-fast: false
       matrix:
         dbimage:
           - mysql:5.7
           - mysql:8.0
-          - mariadb:latest
+          - mariadb:10.2
+          - mariadb:10.6
         dependent:
           - fluent-mysql-driver
     steps:
@@ -62,12 +63,11 @@ jobs:
         dbimage:
           - mysql:5.7
           - mysql:8.0
-          - mariadb:latest
+          - mariadb:10.2
+          - mariadb:10.6
         runner:
           - swift:5.2-focal
-          - swift:5.3-focal
-          - swift:5.4-focal
-          - swiftlang/swift:nightly-5.5-focal
+          - swift:5.5-focal
           - swiftlang/swift:nightly-main-focal
     container: ${{ matrix.runner }}
     runs-on: ubuntu-latest
@@ -94,15 +94,17 @@ jobs:
         formula: 
           - mysql@8.0
           - mysql@5.7
-          - mariadb
+          - mariadb@10.2
+          - mariadb@10.6
         version:
-          - latest
           - latest-stable
         include:
           - username: root
-          - formula: mariadb
+          - formula: mariadb@10.2
             username: runner
-    runs-on: macos-latest
+          - formula: mariadb@10.6
+            username: runner
+    runs-on: macos-11
     steps:
       - name: Select latest available Xcode
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,8 @@ jobs:
           - mysql:8.0
           - mariadb:10.2
           - mariadb:10.6
+          - percona:5.7
+          - percona:8.0
         runner:
           - swift:5.2-focal
           - swift:5.5-focal

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/mysql-nio.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.0.0"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.12.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),

--- a/Sources/MySQLKit/MySQLDialect.swift
+++ b/Sources/MySQLKit/MySQLDialect.swift
@@ -69,4 +69,8 @@ public struct MySQLDialect: SQLDialect {
     public var triggerSyntax: SQLTriggerSyntax {
         return .init(create: [.supportsBody, .conditionRequiresParentheses, .supportsOrder])
     }
+    
+    public var upsertSyntax: SQLUpsertSyntax {
+        .mysqlLike
+    }
 }

--- a/Tests/MySQLKitTests/MySQLKitTests.swift
+++ b/Tests/MySQLKitTests/MySQLKitTests.swift
@@ -6,12 +6,8 @@ import NIOSSL
 import AsyncKit
 
 class MySQLKitTests: XCTestCase {
-    func testSQLKitBenchmark() throws {
-        try self.benchmark.run()
-    }
-    
-    func testEnum() throws {
-        try self.benchmark.testEnum()
+    func testSQLBenchmark() throws {
+        try SQLBenchmarker(on: self.sql).run()
     }
 
     func testNullDecode() throws {
@@ -58,10 +54,6 @@ class MySQLKitTests: XCTestCase {
 
     var mysql: MySQLDatabase {
         self.pools.database(logger: .init(label: "codes.vapor.mysql"))
-    }
-
-    var benchmark: SQLBenchmarker {
-        .init(on: self.sql)
     }
 
     var eventLoopGroup: EventLoopGroup!


### PR DESCRIPTION
Also enables correctly running the expanded SQLKit benchmark suite.

semver-minor because the new SQLKit version requirement is a semver-minor bump.