### PR TITLE
Don't drop an arbitrarily specified database when tests are run

### DIFF
--- a/Tests/MySQLKitTests/MySQLKitTests.swift
+++ b/Tests/MySQLKitTests/MySQLKitTests.swift
@@ -88,15 +88,6 @@ class MySQLKitTests: XCTestCase {
             logger: .init(label: "codes.vapor.mysql"),
             on: self.eventLoopGroup
         )
-
-        // Reset database.
-        _ = try self.mysql.withConnection { conn in
-            return conn.simpleQuery("DROP DATABASE vapor_database").flatMap { _ in
-                conn.simpleQuery("CREATE DATABASE vapor_database")
-            }.flatMap { _ in
-                conn.simpleQuery("USE vapor_database")
-            }
-        }.wait()
     }
 
     override func tearDownWithError() throws {


### PR DESCRIPTION
We shouldn't be resetting databases arbitrarily this way anyway, and removing it fixes a "doesn't honor the MYSQL_DATABASE env var" bug.