### PR TITLE
Declare supported UNION features

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/mysql-nio.git", from: "1.0.0"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.12.0"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.16.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),

--- a/Sources/MySQLKit/MySQLDialect.swift
+++ b/Sources/MySQLKit/MySQLDialect.swift
@@ -73,4 +73,8 @@ public struct MySQLDialect: SQLDialect {
     public var upsertSyntax: SQLUpsertSyntax {
         .mysqlLike
     }
+
+    public var unionFeatures: SQLUnionFeatures {
+        [.union, .unionAll, .explicitDistinct, .parenthesizedSubqueries]
+    }
 }


### PR DESCRIPTION
Leverages the new dialect flags from [vapor/sql-kit#144](https://github.com/vapor/sql-kit#144) to enable full `UNION` queries according to MySQL's support.

The increased SQLKit version requirement makes this a `semver-minor` change.