### PR TITLE
Fix SwiftCrypto version pin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/mysql-nio.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/sql-kit.git", from: "3.16.0"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
     ],


### PR DESCRIPTION
This solves users of Fluent's MySQL driver getting silently stuck on version 1.1.6 of `swift-crypto` (the current, source-compatible version is 2.0.3).

It would be far preferable to replace the usage of `Insecure.SHA1` in `MySQLDialect` with something better suited to the purpose and thus drop the Crypto dependency in MySQLKit altogether, but we can't do that without breaking migrations in existing databases.

Due to the change in dependency version requirement, this is `semver-minor`. 