### PR TITLE
Add locking clause syntax to dialect

### DIFF
--- a/Sources/MySQLKit/MySQLDialect.swift
+++ b/Sources/MySQLKit/MySQLDialect.swift
@@ -77,4 +77,12 @@ public struct MySQLDialect: SQLDialect {
     public var unionFeatures: SQLUnionFeatures {
         [.union, .unionAll, .explicitDistinct, .parenthesizedSubqueries]
     }
+    
+    public var sharedSelectLockExpression: SQLExpression? {
+        SQLRaw("LOCK IN SHARE MODE")
+    }
+    
+    public var exclusiveSelectLockExpression: SQLExpression? {
+        SQLRaw("FOR UPDATE")
+    }
 }


### PR DESCRIPTION
Leverages the new functionality in vapor/sql-kit#154 to provide the correct syntax for both shared and exclusive locking clauses in MySQL.