### PR TITLE
Fix bug in hex encoding of normalized constraint hashes

### DIFF
--- a/Sources/MySQLKit/MySQLDialect.swift
+++ b/Sources/MySQLKit/MySQLDialect.swift
@@ -88,6 +88,6 @@ public struct MySQLDialect: SQLDialect {
 fileprivate let hexTable: [UInt8] = [0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66]
 extension Sequence where Element == UInt8 {
     fileprivate var hexRepresentation: String {
-        .init(decoding: self.flatMap { [hexTable[Int($0 >> 4)], hexTable[Int($0 & 0x7)]] }, as: Unicode.ASCII.self)
+        .init(decoding: self.flatMap { [hexTable[Int($0 >> 4)], hexTable[Int($0 & 0xf)]] }, as: Unicode.ASCII.self)
     }
 }


### PR DESCRIPTION
#314 included a new routine for hex-formatting the hash used for constraint name normalization. This PR fixes a bug in that routine which caused the 4th bit of every byte to be ignored when formatting.