### PR TITLE
Actually support query logging

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,11 +13,11 @@ let package = Package(
         .library(name: "MySQLKit", targets: ["MySQLKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/mysql-nio.git", from: "1.7.1"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.28.0"),
+        .package(url: "https://github.com/vapor/mysql-nio.git", from: "1.7.2"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.29.3"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0" ..< "4.0.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.64.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.26.0"),
     ],
     targets: [
@@ -47,6 +47,4 @@ let package = Package(
 var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ConciseMagicFile"),
     .enableUpcomingFeature("ForwardTrailingClosures"),
-    .enableUpcomingFeature("DisableOutwardActorInference"),
-    .enableExperimentalFeature("StrictConcurrency=complete"),
 ] }

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -13,11 +13,11 @@ let package = Package(
         .library(name: "MySQLKit", targets: ["MySQLKit"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/mysql-nio.git", from: "1.7.1"),
-        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.29.2"),
+        .package(url: "https://github.com/vapor/mysql-nio.git", from: "1.7.2"),
+        .package(url: "https://github.com/vapor/sql-kit.git", from: "3.29.3"),
         .package(url: "https://github.com/vapor/async-kit.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", "2.0.0" ..< "4.0.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.64.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.26.0"),
     ],
     targets: [

--- a/Sources/MySQLKit/MySQLDatabase+SQL.swift
+++ b/Sources/MySQLKit/MySQLDatabase+SQL.swift
@@ -49,7 +49,7 @@ private struct MySQLSQLDatabase<D: MySQLDatabase>: SQLDatabase {
         let (sql, binds) = self.serialize(query)
         
         if let queryLogLevel = self.queryLogLevel {
-            self.logger.log(level: queryLogLevel, "\(sql) \(binds)")
+            self.logger.log(level: queryLogLevel, "Executing query", metadata: ["sql": .string(sql), "binds": .array(binds.map { .string("\($0)") })])
         }
 
         do {
@@ -68,7 +68,7 @@ private struct MySQLSQLDatabase<D: MySQLDatabase>: SQLDatabase {
         let (sql, binds) = self.serialize(query)
         
         if let queryLogLevel = self.queryLogLevel {
-            self.logger.log(level: queryLogLevel, "\(sql) \(binds)")
+            self.logger.log(level: queryLogLevel, "Executing query", metadata: ["sql": .string(sql), "binds": .array(binds.map { .string("\($0)") })])
         }
 
         return try await self.database.value.query(

--- a/Sources/MySQLKit/MySQLDatabase+SQL.swift
+++ b/Sources/MySQLKit/MySQLDatabase+SQL.swift
@@ -10,9 +10,10 @@ extension MySQLDatabase {
     /// - Returns: An instance of `SQLDatabase` which accesses the same database as `self`.
     public func sql(
         encoder: MySQLDataEncoder = .init(),
-        decoder: MySQLDataDecoder = .init()
+        decoder: MySQLDataDecoder = .init(),
+        queryLogLevel: Logger.Level? = .debug
     ) -> any SQLDatabase {
-        MySQLSQLDatabase(database: .init(value: self), encoder: encoder, decoder: decoder)
+        MySQLSQLDatabase(database: .init(value: self), encoder: encoder, decoder: decoder, queryLogLevel: queryLogLevel)
     }
 }
 
@@ -40,10 +41,17 @@ private struct MySQLSQLDatabase<D: MySQLDatabase>: SQLDatabase {
     // See `SQLDatabase.dialect`.
     var dialect: any SQLDialect { MySQLDialect() }
     
+    // See `SQLDatabase.queryLogLevel`.
+    let queryLogLevel: Logger.Level?
+    
     // See `SQLDatabase.execute(sql:_:)`.
     func execute(sql query: any SQLExpression, _ onRow: @escaping @Sendable (any SQLRow) -> ()) -> EventLoopFuture<Void> {
         let (sql, binds) = self.serialize(query)
         
+        if let queryLogLevel = self.queryLogLevel {
+            self.logger.log(level: queryLogLevel, "\(sql) \(binds)")
+        }
+
         do {
             return try self.database.value.query(
                 sql,
@@ -59,6 +67,10 @@ private struct MySQLSQLDatabase<D: MySQLDatabase>: SQLDatabase {
     func execute(sql query: any SQLExpression, _ onRow: @escaping @Sendable (any SQLRow) -> ()) async throws {
         let (sql, binds) = self.serialize(query)
         
+        if let queryLogLevel = self.queryLogLevel {
+            self.logger.log(level: queryLogLevel, "\(sql) \(binds)")
+        }
+
         return try await self.database.value.query(
             sql,
             binds.map { try self.encoder.encode($0) },


### PR DESCRIPTION
Now supports query logging with the same semantics as the other drivers. When a query is executed with query logging enabled at or above the logger's current log level, the actual SQL query and its accompanying array of bound parameters (if any) are logged as structured metadata on the logger using a generic message. This follows the [recommended guidelines for logging in libraries](https://www.swift.org/documentation/server/guides/libraries/log-levels.html). Credit goes to @MahdiBM for the original suggestion.

Before:
```
2024-05-29T00:00:00Z debug codes.vapor.fluent : database-id=mysql [MySQLKit] SELECT * FROM foo WHERE a=? [["bar"]]
```
After:
```
2024-05-29T00:00:00Z debug codes.vapor.fluent : database-id=mysql sql=SELECT * FROM foo WHERE a=? binds=["bar"] [MySQLKit] Executing query
```
<br>
Also bumps dependency minimums.
